### PR TITLE
Make Tasks Field Flexible in common_issue.yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/common_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/common_issue.yaml
@@ -21,15 +21,18 @@ body:
     validations:
       required: false
 
-  - type: checkboxes
+  - type: textarea
     id: tasks
     attributes:
       label: Tasks
-      description: List the tasks required to complete this issue.
-      options:
-        - label: Task 1
-        - label: Task 2
-        - label: Task 3
+      description: List the required tasks in bullet points. You may add as many lines as needed.
+      placeholder: |
+        - Task 1
+        - Task 2
+        - Task 3
+    validations:
+      required: false
+
 
   - type: textarea
     id: acceptance_criteria


### PR DESCRIPTION
# Summary
Update `common_issue.yaml` to make the `tasks` field flexible by changing its type from checkboxes to a textarea, allowing users to freely add or remove task items.

# Relationships
- #42

# Changes
- Changed `tasks` field type from `checkboxes` to `textarea`
- Added placeholder with bullet-point examples
- Updated description to clarify free-form task entry
- Verified that the Issue Form renders correctly with the new field type

# Notes
No breaking changes.  
This update improves usability for contributors who need variable-length task lists.
