### PR TITLE
Move Unreleased PR Entries into the [Unreleased] Section of CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Initial repository setup with `.gitignore`, `README.md` and `LICENSE`
 - Added `CHANGELOG.md` ([#6](https://github.com/Min-prog000/titanic-analysis/pull/6), fixes [#5](https://github.com/Min-prog000/titanic-analysis/issues/5))
 - Added `CONTRIBUTING.md` ([#12](https://github.com/Min-prog000/titanic-analysis/pull/12), fixes [#11](https://github.com/Min-prog000/titanic-analysis/issues/11))
 - Setup `uv` project ([#14](https://github.com/Min-prog000/titanic-analysis/pull/14), fixes [#7](https://github.com/Min-prog000/titanic-analysis/issues/7))


### PR DESCRIPTION
# Summary
Some unreleased pull request entries were not placed under the `[Unreleased]` section.
This update reorganizes the CHANGELOG.md to ensure the correct structure is maintained.

# Changes
- Moved unreleased change log entries into the `[Unreleased]` section
- Improved consistency of the section structure
- Cleaned up entries that were located in incorrect sections

# Impact
- Enhances readability and maintainability of the CHANGELOG
- Helps streamline future release processes

# Verification
- Verified that all unreleased entries are correctly placed under `[Unreleased]`
- Confirmed that the section structure remains intact

# Related Issues
- #49

# Notes
- Continue adding unreleased changes under the `[Unreleased]` section as part of the workflow

# Checklist
- [x] Reviewed CHANGELOG.md structure
- [x] Moved unreleased entries to `[Unreleased]`
- [x] Ensured no unnecessary changes are included