### PR TITLE
Prepare Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,37 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Added `CHANGELOG.md` ([#6](https://github.com/Min-prog000/titanic-analysis/pull/6), fixes [#5](https://github.com/Min-prog000/titanic-analysis/issues/5))
-- Added `CONTRIBUTING.md` ([#12](https://github.com/Min-prog000/titanic-analysis/pull/12), fixes [#11](https://github.com/Min-prog000/titanic-analysis/issues/11))
-- Setup `uv` project ([#14](https://github.com/Min-prog000/titanic-analysis/pull/14), fixes [#7](https://github.com/Min-prog000/titanic-analysis/issues/7))
-  - Create `uv` project using `uv init` ([#14](https://github.com/Min-prog000/titanic-analysis/pull/14), fixes [#8](https://github.com/Min-prog000/titanic-analysis/issues/8))
-  - Added `.venv` in local environment ([#14](https://github.com/Min-prog000/titanic-analysis/pull/14), fixes [#9](https://github.com/Min-prog000/titanic-analysis/issues/9))
-- Introduced custom package structure under `src/titanic_analysis`: ([#23](https://github.com/Min-prog000/titanic-analysis/pull/23), fixes [#20](https://github.com/Min-prog000/titanic-analysis/issues/20))
-  - **domain**: core business logic and entities
-  - **framework**: application framework and external interfaces
-  - **infrastructure**: data access and system-level implementations
-  - **usecase**: application-specific use cases and workflows
 - Migrated `main.ipynb` from private repository ([#24](https://github.com/Min-prog000/titanic-analysis/pull/24), fixes [#21](https://github.com/Min-prog000/titanic-analysis/issues/21))
 - Added `requirements.txt` ([#33](https://github.com/Min-prog000/titanic-analysis/pull/33), fixes [#31](https://github.com/Min-prog000/titanic-analysis/issues/31))
 
 ### Changed
 
-- Updated documentations related `LICENSE`
-  - Updated `LICENSE` with copyright notice (2025 Minplu) ([#3](https://github.com/Min-prog000/titanic-analysis/pull/3), fixes [#1](https://github.com/Min-prog000/titanic-analysis/issues/1))
-  - Added "License" section to `README.md` referencing `LICENSE` ([#4](https://github.com/Min-prog000/titanic-analysis/pull/4), fixes [#2](https://github.com/Min-prog000/titanic-analysis/issues/2))
-- Setup `uv` project ([#14](https://github.com/Min-prog000/titanic-analysis/pull/14), fixes [#7](https://github.com/Min-prog000/titanic-analysis/issues/7))
-  - Updated `.gitignore` to validate to `.vscode`, `uv.lock` and `.python-version` ([#14](https://github.com/Min-prog000/titanic-analysis/pull/14), fixes [#13](https://github.com/Min-prog000/titanic-analysis/issues/13))
-  - Updated libraries dependencies to `pyproject.toml` ([#14](https://github.com/Min-prog000/titanic-analysis/pull/14), fixes [#10](https://github.com/Min-prog000/titanic-analysis/issues/10))
-    - `numpy`
-    - `pandas`
-    - `scikit-learn`
-- Updated `pyproject.toml` to add linter setting with `Ruff` ([#18](https://github.com/Min-prog000/titanic-analysis/pull/18), fixes [#17](https://github.com/Min-prog000/titanic-analysis/issues/17))
-- Move `main.py` to `src/titanic_analysis` ([#23](https://github.com/Min-prog000/titanic-analysis/pull/23), fixes [#20](https://github.com/Min-prog000/titanic-analysis/issues/20))
-- Adjust `main.py` to execution using `uv run` ([#23](https://github.com/Min-prog000/titanic-analysis/pull/23), fixes [#20](https://github.com/Min-prog000/titanic-analysis/issues/20))
-- Revised `README.md` with Kaggle dataset usage instructions ([#23](https://github.com/Min-prog000/titanic-analysis/pull/23), fixes [#20](https://github.com/Min-prog000/titanic-analysis/issues/20))
-- Updated `pyproject.toml` to add dependencies ([#23](https://github.com/Min-prog000/titanic-analysis/pull/23), fixes [#20](https://github.com/Min-prog000/titanic-analysis/issues/20))
-  - `pyyaml`
-  - `pydantic`
 - Rename migrated `main.ipynb` to `main_notebook.ipynb` ([#24](https://github.com/Min-prog000/titanic-analysis/pull/24), fixes [#21](https://github.com/Min-prog000/titanic-analysis/issues/21))
 - Updated `README.md` to revise outlines and dataset URL, and add execution and installation instructions ([#33](https://github.com/Min-prog000/titanic-analysis/pull/33), fixes [#30](https://github.com/Min-prog000/titanic-analysis/issues/30))
 - Updated `CHANGELOG.md` to log previous update point ([#33](https://github.com/Min-prog000/titanic-analysis/pull/33), fixes [#32](https://github.com/Min-prog000/titanic-analysis/issues/32))
@@ -68,3 +42,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Duplicated
 
 (None)
+
+## [0.1.0] - 2025-12-31
+
+### Added
+
+- Added `CHANGELOG.md` ([#6](https://github.com/Min-prog000/titanic-analysis/pull/6), fixes [#5](https://github.com/Min-prog000/titanic-analysis/issues/5))
+- Added `CONTRIBUTING.md` ([#12](https://github.com/Min-prog000/titanic-analysis/pull/12), fixes [#11](https://github.com/Min-prog000/titanic-analysis/issues/11))
+- Setup `uv` project ([#14](https://github.com/Min-prog000/titanic-analysis/pull/14), fixes [#7](https://github.com/Min-prog000/titanic-analysis/issues/7))
+  - Create `uv` project using `uv init` ([#14](https://github.com/Min-prog000/titanic-analysis/pull/14), fixes [#8](https://github.com/Min-prog000/titanic-analysis/issues/8))
+  - Added `.venv` in local environment ([#14](https://github.com/Min-prog000/titanic-analysis/pull/14), fixes [#9](https://github.com/Min-prog000/titanic-analysis/issues/9))
+- Introduced custom package structure under `src/titanic_analysis`: ([#23](https://github.com/Min-prog000/titanic-analysis/pull/23), fixes [#20](https://github.com/Min-prog000/titanic-analysis/issues/20))
+  - **domain**: core business logic and entities
+  - **framework**: application framework and external interfaces
+  - **infrastructure**: data access and system-level implementations
+  - **usecase**: application-specific use cases and workflows
+
+### Changed
+
+- Updated documentations related `LICENSE`
+  - Updated `LICENSE` with copyright notice (2025 Minplu) ([#3](https://github.com/Min-prog000/titanic-analysis/pull/3), fixes [#1](https://github.com/Min-prog000/titanic-analysis/issues/1))
+  - Added "License" section to `README.md` referencing `LICENSE` ([#4](https://github.com/Min-prog000/titanic-analysis/pull/4), fixes [#2](https://github.com/Min-prog000/titanic-analysis/issues/2))
+- Setup `uv` project ([#14](https://github.com/Min-prog000/titanic-analysis/pull/14), fixes [#7](https://github.com/Min-prog000/titanic-analysis/issues/7))
+  - Updated `.gitignore` to validate to `.vscode`, `uv.lock` and `.python-version` ([#14](https://github.com/Min-prog000/titanic-analysis/pull/14), fixes [#13](https://github.com/Min-prog000/titanic-analysis/issues/13))
+  - Updated libraries dependencies to `pyproject.toml` ([#14](https://github.com/Min-prog000/titanic-analysis/pull/14), fixes [#10](https://github.com/Min-prog000/titanic-analysis/issues/10))
+    - `numpy`
+    - `pandas`
+    - `scikit-learn`
+- Updated `pyproject.toml` to add linter setting with `Ruff` ([#18](https://github.com/Min-prog000/titanic-analysis/pull/18), fixes [#17](https://github.com/Min-prog000/titanic-analysis/issues/17))
+- Move `main.py` to `src/titanic_analysis` ([#23](https://github.com/Min-prog000/titanic-analysis/pull/23), fixes [#20](https://github.com/Min-prog000/titanic-analysis/issues/20))
+- Adjust `main.py` to execution using `uv run` ([#23](https://github.com/Min-prog000/titanic-analysis/pull/23), fixes [#20](https://github.com/Min-prog000/titanic-analysis/issues/20))
+- Revised `README.md` with Kaggle dataset usage instructions ([#23](https://github.com/Min-prog000/titanic-analysis/pull/23), fixes [#20](https://github.com/Min-prog000/titanic-analysis/issues/20))
+- Updated `pyproject.toml` to add dependencies ([#23](https://github.com/Min-prog000/titanic-analysis/pull/23), fixes [#20](https://github.com/Min-prog000/titanic-analysis/issues/20))
+  - `pyyaml`
+  - `pydantic`


### PR DESCRIPTION
# Summary
Prepare the v0.1.0 release by updating the CHANGELOG.  
Moved all entries from the [Unreleased] section into the new v0.1.0 section.

# Changes
- Updated `CHANGELOG.md` for the v0.1.0 release
- Moved all relevant entries from [Unreleased] to the new version section

# Impact
- Establishes the first public release of the project
- Provides a clear and accurate record of changes included in v0.1.0

# Verification
- Confirmed that `CHANGELOG.md` reflects the correct structure
- Verified that no unrelated modifications were introduced
- Checked that the version section matches the intended release content

# Related Issues
- #36

# Notes
- This PR prepares the repository for tagging and creating the v0.1.0 release

# Checklist
- [x] CHANGELOG updated
- [x] Related contents cleared from [Unreleased] section
- [x] Version section created for v0.1.0