### PR TITLE
Prepare Release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- Fix codes because of verifying successful execution of `main_notebook.ipynb` ([#29](https://github.com/Min-prog000/titanic-analysis/pull/29), fixes [#26](https://github.com/Min-prog000/titanic-analysis/issues/26))
+(None)
 
 ### Model
 
@@ -39,6 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Duplicated
 
 (None)
+
+## [0.2.2] - 2026-01-02
+
+### Fixed
+
+- Fix codes because of verifying successful execution of `main_notebook.ipynb` ([#29](https://github.com/Min-prog000/titanic-analysis/pull/29), fixes [#26](https://github.com/Min-prog000/titanic-analysis/issues/26))
 
 ## [0.2.1] - 2026-01-01
 


### PR DESCRIPTION
## Summary
The bug fix for `main_notebook.ipynb` was completed in a separate branch.  
This PR updates the CHANGELOG to prepare the fix for the v0.2.2 release by moving the corresponding entry from the `[Unreleased]` section to `[v0.2.2]`.

## Changes
- Moved the bug fix entry in `CHANGELOG.md` from `[Unreleased]` to `[v0.2.2]`
- Applied only the minimal updates required for the release preparation

## Impact
- Ensures that the v0.2.2 release notes accurately reflect the included bug fix
- Improves consistency between the actual fix and the documented release history
- Keeps versioning and CHANGELOG management aligned

## Verification
- Verified that the `[v0.2.2]` section in `CHANGELOG.md` is correctly updated
- Confirmed that no unintended changes are included in this PR

## Related Issues
- #36

## Notes
Ideally, the bug fix and the CHANGELOG update would be handled in the same branch.  
However, since the fix was already completed elsewhere, this PR focuses solely on updating the CHANGELOG for the v0.2.2 release.

## Checklist
- [x] Moved the CHANGELOG entry to `[v0.2.2]`
- [x] Verified no unrelated changes are included