### PR TITLE
Replace typing.Iterator with collections.abc.Iterator

### DIFF
--- a/src/titanic_analysis/domain/dataset/dataset.py
+++ b/src/titanic_analysis/domain/dataset/dataset.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Iterator
+from typing import TYPE_CHECKING
 
 import pandas as pd
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 class Dataset(ABC):


### PR DESCRIPTION
## Summary
Ruff reported a warning for using `typing.Iterator`, so the import has been updated to the recommended `collections.abc.Iterator`.

## Changes
- Replaced `from typing import Iterator` with `from collections.abc import Iterator`

## Impact
- Resolves Ruff warnings and improves code quality
- Aligns with recommended typing practices for Python 3.9+
- Prevents future deprecation-related warnings

## Verification
- Confirmed Ruff passes without warnings
- All existing tests pass successfully
- Verified type checking (e.g., mypy) works without issues

## Related Issues
- #82

## Notes
- Additional migrations from `typing` to `collections.abc` may be needed depending on future Ruff rules

## Checklist
- [x] Ruff warnings resolved
- [x] Linting and type checks pass
- [x] Changes are minimal and isolated
